### PR TITLE
編集画面に完了ボタンを追加。editor/pickerの背景色をfieldと統一

### DIFF
--- a/artifacts analyzer admin app/Assets.xcassets/darkPrimary.colorset/Contents.json
+++ b/artifacts analyzer admin app/Assets.xcassets/darkPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0",
+          "green" : "0",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/artifacts analyzer admin app/Views/Artifact/ArtifactHomeView.swift
+++ b/artifacts analyzer admin app/Views/Artifact/ArtifactHomeView.swift
@@ -49,5 +49,6 @@ struct ArtifactHomeView: View {
                     DisplayArtifactDetailView(path: $navigationPath, artifactViewModel: artifactViewModel)
                 }
             }
-        }}
+        }
+    }
 }

--- a/artifacts analyzer admin app/Views/Artifact/DisplayArtifactDetailView.swift
+++ b/artifacts analyzer admin app/Views/Artifact/DisplayArtifactDetailView.swift
@@ -169,10 +169,18 @@ struct DisplayArtifactDetailView: View {
                     }
                     .disabled(!isValidField() && isEditing)
                 }
+                
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完了") {
+                        isKeyboardActive = false // キーボード閉じる
+                    }
+                }
             }
         } else {
             Text("情報取得に失敗しました")
                 .foregroundColor(.gray)
+                .navigationTitle("聖遺物詳細")
         }
     }
     

--- a/artifacts analyzer admin app/Views/Artifact/DisplayArtifactsView.swift
+++ b/artifacts analyzer admin app/Views/Artifact/DisplayArtifactsView.swift
@@ -15,13 +15,13 @@ struct DisplayArtifactsView: View {
                         }
                     }.foregroundColor(.primary)
                 }
-                .navigationTitle("聖遺物一覧")
             } else if artifactViewModel.isLoadingArtifacts {
                 BlockingIndicator()
             } else {
                 Text("No artifact")
             }
         }
+        .navigationTitle("聖遺物一覧")
         .onAppear {
             Task {
                 await artifactViewModel.fetchAllArtifacts()

--- a/artifacts analyzer admin app/Views/Character/CharacterHomeView.swift
+++ b/artifacts analyzer admin app/Views/Character/CharacterHomeView.swift
@@ -49,5 +49,6 @@ struct CharacterHomeView: View {
                     DisplayCharacterDetailView(path: $navigationPath, characterViewModel: characterViewModel)
                 }
             }
-        }}
+        }
+    }
 }

--- a/artifacts analyzer admin app/Views/Character/DisplayCharacterDetailView.swift
+++ b/artifacts analyzer admin app/Views/Character/DisplayCharacterDetailView.swift
@@ -119,6 +119,14 @@ struct DisplayCharacterDetailView: View {
                         }
                     } else {
                         EmptyView() // デフォルトの戻るボタン
+//                        Button(action:{path.removeLast()}){
+//                            HStack{
+//                                Image(systemName: "chevron.left")
+//                                    .foregroundColor(.appTheme)
+//                                Text("キャラクター一覧")
+//                                    .foregroundColor(.appTheme)
+//                            }
+//                        }
                     }
                 }
                 
@@ -192,6 +200,13 @@ struct DisplayCharacterDetailView: View {
                         }
                     }
                     .disabled(!isValidField() && isEditing) // 編集中かつinvalid項目があれば完了を押せない
+                }
+                
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完了") {
+                        isKeyboardActive = false // キーボード閉じる
+                    }
                 }
             }
         } else {

--- a/artifacts analyzer admin app/Views/Character/DisplayCharactersView.swift
+++ b/artifacts analyzer admin app/Views/Character/DisplayCharactersView.swift
@@ -15,13 +15,13 @@ struct DisplayCharactersView: View {
                         }
                     }.foregroundColor(.primary)
                 }
-                .navigationTitle("キャラクター一覧")
             } else if characterViewModel.isLoadingAllCharacters {
                 BlockingIndicator() // 全画面ブロッキングインジケータ
             } else {
                 Text("No character")
             }
         }
+        .navigationTitle("キャラクター一覧")
         .onAppear {
             Task {
                 await characterViewModel.fetchAllCharacters()

--- a/artifacts analyzer admin app/Views/Weapon/DisplayWeaponDetailView.swift
+++ b/artifacts analyzer admin app/Views/Weapon/DisplayWeaponDetailView.swift
@@ -188,6 +188,13 @@ struct DisplayWeaponDetailView: View {
                     }
                     .disabled(!isValidField() && isEditing)
                 }
+                
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完了") {
+                        isKeyboardActive = false // キーボード閉じる
+                    }
+                }
             }
         } else {
             Text("エラーが発生しました")

--- a/artifacts analyzer admin app/Views/Weapon/DisplayWeaponsView.swift
+++ b/artifacts analyzer admin app/Views/Weapon/DisplayWeaponsView.swift
@@ -15,13 +15,13 @@ struct DisplayWeaponsView: View {
                         }
                     }.foregroundColor(.primary)
                 }
-                .navigationTitle("武器一覧")
             } else if weaponViewModel.isLoadingWeapons {
                 BlockingIndicator() // 全画面ブロッキングインジケータ
             } else {
                 Text("No weapon")
             }
         }
+        .navigationTitle("武器一覧")
         .onAppear {
             Task {
                 await weaponViewModel.fetchAllWeapons()

--- a/artifacts analyzer admin app/Views/Weapon/WeaponHomeView.swift
+++ b/artifacts analyzer admin app/Views/Weapon/WeaponHomeView.swift
@@ -49,5 +49,6 @@ struct WeaponHomeView: View {
                     DisplayWeaponDetailView(path: $navigationPath, weaponViewModel: weaponViewModel)
                 }
             }
-        }}
+        }
+    }
 }

--- a/artifacts analyzer admin app/Views/Widgets/LeftLabeledTextEditor.swift
+++ b/artifacts analyzer admin app/Views/Widgets/LeftLabeledTextEditor.swift
@@ -33,7 +33,8 @@ struct LeftLabeledTextEditor: View {
                     RoundedRectangle(cornerRadius: 5)
                         .stroke(Color(UIColor.systemGray6))
                 )
-            
+                .scrollContentBackground(.hidden)
+                .background(Color.darkPrimary)
         }
     }
 }

--- a/artifacts analyzer admin app/Views/Widgets/LeftLabeledTextField.swift
+++ b/artifacts analyzer admin app/Views/Widgets/LeftLabeledTextField.swift
@@ -28,6 +28,11 @@ struct LeftLabeledTextField: View {
                 }
                 .pickerStyle(.wheel)
                 .frame(height: 100)
+                .background(
+                    Color.darkPrimary // 背景色指定
+                        .cornerRadius(5)
+                )
+                .clipped()
             } else {
                 TextField("", text: $text)
                     .multilineTextAlignment(TextAlignment.trailing)


### PR DESCRIPTION
## 概要
- 編集画面のUIを調整

## 関連タスク
- #16 
- #17 

## やったこと
- 編集画面でキーボードを出した時に完了ボタンがない不具合の修正
- ダークモード時、fieldは黒背景に対して、editor/pickerには色がなかった問題の修正

## その他
-
