### PR TITLE
hoyolab IDの入力に、URLそのままの入力も許可

### DIFF
--- a/artifacts analyzer admin app/Views/Artifact/AddArtifactView.swift
+++ b/artifacts analyzer admin app/Views/Artifact/AddArtifactView.swift
@@ -52,7 +52,7 @@ struct AddArtifactView: View {
                         }
                         
                         HStack {
-                            LabeledTextField(label: "hoyolab ID", text: $id, numberType: "Int", focusField: $isKeyboardActive)
+                            LabeledTextField(label: "hoyolab URL または ID", text: $id, focusField: $isKeyboardActive)
                             Button("自動取得", action: {
                                 // キーボードを閉じる
                                 isKeyboardActive = false
@@ -60,6 +60,17 @@ struct AddArtifactView: View {
                                 // 初期化
                                 resetField()
                                 imgUrlList = Array(repeating: nil, count: 5)
+                                
+                                // 入力のパターンがURL
+                                if let url = URL(string: id) {
+                                    id = url.lastPathComponent // 最後のpathを取得
+                                }
+                                if Int(id) == nil  {
+                                    id = ""
+                                    errorCreateFlg = true
+                                    errorMessage = "自動取得において不正な値が入力されました"
+                                    return
+                                }
                                 
                                 // スクレイピング開始
                                 artifactViewModel.fetchArtifactAPI(

--- a/artifacts analyzer admin app/Views/Character/AddCharacterView.swift
+++ b/artifacts analyzer admin app/Views/Character/AddCharacterView.swift
@@ -55,13 +55,23 @@ struct AddCharacterView: View {
                     }
                     
                     HStack {
-                        LabeledTextField(label: "hoyolab ID", text: $id, numberType: "Int", focusField: $isKeyboardActive)
+                        LabeledTextField(label: "hoyolab URL または ID", text: $id, focusField: $isKeyboardActive)
                         Button("自動取得", action: {
                             isKeyboardActive = false
                             // 初期化
                             resetField()
-                            // スクレイピング開始
-                            isScrape.toggle()
+                            // 入力のパターンがURL
+                            if let url = URL(string: id) {
+                                id = url.lastPathComponent // 最後のpathを取得
+                            }
+                            if Int(id) != nil {
+                                // スクレイピング開始
+                                isScrape.toggle()
+                            } else {
+                                id = ""
+                                errorCreateFlg = true
+                                errorMessage = "自動取得において不正な値が入力されました"
+                            }
                         })
                         .disabled(id.isEmpty)
                         .buttonStyle(.bordered).padding(.top,20)

--- a/artifacts analyzer admin app/Views/Weapon/AddWeaponView.swift
+++ b/artifacts analyzer admin app/Views/Weapon/AddWeaponView.swift
@@ -64,7 +64,7 @@ struct AddWeaponView: View {
                         }
                         
                         HStack {
-                            LabeledTextField(label: "hoyolab ID", text: $id, numberType: "Int", focusField: $isKeyboardActive)
+                            LabeledTextField(label: "hoyolab URL または ID", text: $id, focusField: $isKeyboardActive)
                             Button("自動取得", action: {
                                 // キーボードを閉じる
                                 isKeyboardActive = false
@@ -72,6 +72,17 @@ struct AddWeaponView: View {
                                 // 全てのfieldを初期化
                                 resetField()
                                 imgUrl = nil
+                                
+                                // 入力のパターンがURL
+                                if let url = URL(string: id) {
+                                    id = url.lastPathComponent // 最後のpathを取得
+                                }
+                                if Int(id) == nil  {
+                                    id = ""
+                                    errorCreateFlg = true
+                                    errorMessage = "自動取得において不正な値が入力されました"
+                                    return
+                                }
                                 
                                 weaponViewModel.fetchWeaponAPI(
                                     id: id,


### PR DESCRIPTION
## 概要
- 各追加画面のhoyolab ID入力欄のUXを向上

## 関連タスク
- #15 

## やったこと
- hoyolab ID入力欄に、URLをそのまま貼ることも許可
- URLの末尾pathからIDを抽出

## その他
-
