### PR TITLE
キャラクター画像の自動取得。追加操作の日時記録。

### DIFF
--- a/artifacts analyzer admin app/ViewModels/CharacterViewModel.swift
+++ b/artifacts analyzer admin app/ViewModels/CharacterViewModel.swift
@@ -45,36 +45,61 @@ class CharacterViewModel: ObservableObject {
     }
     
     func createCharacter(character: Character, completion: @escaping () -> Void, errorHandling: @escaping () -> Void) {
-        do {
-            // キャラクターのパラメータを保存
-            try db.collection("characters").document(character.enName).collection("parameter").document("parameter").setData(from: character) { error in
+        self.saveParameters(for: character) { error in
+            if let error = error {
+                print("parameters書き込みエラー: \(error)")
+                errorHandling()
+                return
+            }
+            
+            self.saveDigest(for: character) { error in
                 if let error = error {
-                    print("parameters書き込みエラー: \(error)")
+                    print("digest書き込みエラー: \(error)")
                     errorHandling()
                     return
                 }
-                    
-                // キャラクターのダイジェストを保存
-                let characterDigest: CharacterDigest = CharacterDigest (element: character.element, enName: character.enName, imgUrl: character.imgUrl, jpName: character.jpName, rarity: character.rarity, hoyolabId: character.hoyolabId)
-                do {
-                    try db.collection("characters").document(character.enName).setData(from: characterDigest) { error in
-                        if let error = error {
-                            print("digest書き込みエラー: \(error)")
-                            errorHandling()
-                        } else {
-                            // 選択中のデータも更新しておく
-                            self.character = character
-                            completion()
-                        }
+                
+                db.collection("admin").document("createTimestamp").updateData(["createdCharacter": FieldValue.serverTimestamp()]) { error in
+                    if let error = error {
+                        print("timestamp書き込みエラー: \(error)")
+                        errorHandling()
+                        return
                     }
-                } catch {
-                    print("digest書き込みエラー: \(error)")
-                    errorHandling()
+                    
+                    self.character = character
+                    completion()
                 }
             }
+        }
+    }
+    
+    private func saveParameters(for character: Character, completion: @escaping (Error?) -> Void) {
+        do {
+            try db.collection("characters")
+                .document(character.enName)
+                .collection("parameter")
+                .document("parameter")
+                .setData(from: character, completion: completion)
         } catch {
-            print("parameters書き込みエラー: \(error)")
-            errorHandling()
+            completion(error)
+        }
+    }
+    
+    private func saveDigest(for character: Character, completion: @escaping (Error?) -> Void) {
+        let digest = CharacterDigest(
+            element: character.element,
+            enName: character.enName,
+            imgUrl: character.imgUrl,
+            jpName: character.jpName,
+            rarity: character.rarity,
+            hoyolabId: character.hoyolabId
+        )
+        do {
+            try db.collection("characters")
+                .document(character.enName)
+                .setData(from: digest, completion: completion)
+        } catch {
+            completion(error)
         }
     }
 }

--- a/artifacts analyzer admin app/ViewModels/WeaponViewModel.swift
+++ b/artifacts analyzer admin app/ViewModels/WeaponViewModel.swift
@@ -34,10 +34,20 @@ class WeaponViewModel: ObservableObject {
                 if error != nil {
                     errorHandling()
                     return
-                } else {
+                }
+                
+                db.collection("admin").document("createTimestamp").updateData(["createdWeapon": FieldValue.serverTimestamp()]) { error in
+                    if let error = error {
+                        print("timestamp書き込みエラー: \(error)")
+                        errorHandling()
+                        return
+                    }
+                    
                     self.selectedWeapon = weapon
                     completion()
                 }
+                
+                
             }
         } catch {
             errorHandling()

--- a/artifacts analyzer admin app/Views/Character/ScrapingCharacter.swift
+++ b/artifacts analyzer admin app/Views/Character/ScrapingCharacter.swift
@@ -4,7 +4,7 @@ import SwiftSoup
 
 struct ScrapingCharacter: UIViewRepresentable {
     let url: URL
-    let onLoaded: (String, [String], [String]) -> Void
+    let onLoaded: (String, [String], [String], String) -> Void
     let onLoading: () -> Void
     let onError: () -> Void
     
@@ -23,12 +23,11 @@ struct ScrapingCharacter: UIViewRepresentable {
                         let texts: Elements = try doc.select("div.ProseMirror p")
                         let tags: Elements = try doc.select("div.c-entry-tag-item.active.genshin")
                         let parameters: Elements = try doc.select("td.m-d-ascension-td")
-                        if let element = try doc.select("meta[property=og:image]").first() {
-                            let content = try element.attr("content")
-                            print(content)
-                        }
+                        let imgs = try doc.select("meta[property=og:image]")
                         
-                        if texts.count >= 2 && tags.count >= 1 && parameters.count >= 80 {
+                        if texts.count >= 2 && tags.count >= 1 && parameters.count >= 80 && imgs.count >= 1 {
+                            let imgUrl = try imgs[0].attr("content")
+                            
                             let name = try texts[1].text()
                             
                             var tagTexts: [String] = []
@@ -44,7 +43,7 @@ struct ScrapingCharacter: UIViewRepresentable {
                                 parameterTexts.append(parameterText)
                             }
                             
-                            self.parent.onLoaded(name, tagTexts, parameterTexts)
+                            self.parent.onLoaded(name, tagTexts, parameterTexts, imgUrl)
                         } else {
                             self.parent.onError()
                         }


### PR DESCRIPTION
## 概要
- キャラクター追加の修正
- 武器追加の修正
- 聖遺物追加の修正

## 関連タスク
- #18 
- #21 

## やったこと
- キャラクター画像の取得を自動化
- キャラクター・武器・聖遺物追加時に更新日時をfirestoreに記録

## その他
-
