### PR TITLE
画像追加の処理をfirebase storageに保存するように変更

### DIFF
--- a/artifacts analyzer admin app/Views/Character/AddCharacterView.swift
+++ b/artifacts analyzer admin app/Views/Character/AddCharacterView.swift
@@ -120,15 +120,27 @@ struct AddCharacterView: View {
                             isKeyboardActive = false
                             isCreate.toggle()
                             
-                            if let data = selectedImageData {
-                                imgUrl = await uploadImageViewModel.uploadImage(
-                                    data: data,
-                                    imgType: "character",
-                                    imgName: enName
-                                )
+                            // 外部から取得した画像urlがある場合、selectedImageDataに落とし込む
+                            if let url = imgUrl {
+                                let (data, _) = try await URLSession.shared.data(from: url)
+                                selectedImageData = data
                             }
                             
-                            guard let url = imgUrl else {
+                            // selectedImageDataのguard
+                            guard let imageData = selectedImageData else {
+                                isCreate.toggle()
+                                errorCreateFlg = true
+                                errorMessage = "キャラクター画像が選択されていません"
+                                return
+                            }
+                            
+                            // storageにアップロード
+                            let url = await uploadImageViewModel.uploadImage(
+                                data: imageData,
+                                imgType: "character",
+                                imgName: enName
+                            )
+                            if url == nil {
                                 isCreate.toggle()
                                 errorCreateFlg = true
                                 errorMessage = "キャラクター画像が正しくありません"
@@ -143,7 +155,7 @@ struct AddCharacterView: View {
                                 enName: enName,
                                 extraStatusName: extraStatusName,
                                 extraStatusValue: Double(extraStatusValue) ?? 0,
-                                imgUrl: url,
+                                imgUrl: url!,
                                 jpName: jpName,
                                 rarity: Int(rarity) ?? 0,
                                 weaponType: weaponType,

--- a/artifacts analyzer admin app/Views/Weapon/AddWeaponView.swift
+++ b/artifacts analyzer admin app/Views/Weapon/AddWeaponView.swift
@@ -192,15 +192,27 @@ struct AddWeaponView: View {
                                 isKeyboardActive = false
                                 isCreate.toggle()
                                 
-                                if let data = selectedImageData {
-                                    imgUrl = await uploadImageViewModel.uploadImage(
-                                        data: data,
-                                        imgType: "weapon",
-                                        imgName: enName
-                                    )
+                                // 外部から取得した画像urlがある場合、selectedImageDataに落とし込む
+                                if let url = imgUrl {
+                                    let (data, _) = try await URLSession.shared.data(from: url)
+                                    selectedImageData = data
                                 }
                                 
-                                guard let imgUrl = imgUrl else {
+                                // selectedImageDataのguard
+                                guard let imageData = selectedImageData else {
+                                    isCreate.toggle()
+                                    errorCreateFlg = true
+                                    errorMessage = "武器画像が選択されていません"
+                                    return
+                                }
+                                
+                                // storageにアップロード
+                                let url = await uploadImageViewModel.uploadImage(
+                                    data: imageData,
+                                    imgType: "weapon",
+                                    imgName: enName
+                                )
+                                if url == nil {
                                     isCreate.toggle()
                                     errorCreateFlg = true
                                     errorMessage = "武器画像が正しくありません"
@@ -212,7 +224,7 @@ struct AddWeaponView: View {
                                     effectSentence: [""], // 後で更新
                                     enName: enName,
                                     finalEffectValue: [0.0], // 後で更新
-                                    imgUrl: imgUrl,
+                                    imgUrl: url!,
                                     initialEffectValue: [0.0], // 後で更新
                                     jpName: jpName,
                                     rarity: Int(rarity) ?? 0,


### PR DESCRIPTION
## 概要
- 画像は全てfirebase storageに保存する

## 関連タスク
-

## やったこと
- 公式APIのurlでは画像を表示できないことが判明した
- 画像はstorageに格納してから、そのurlをfirestoreに保存する

## その他
-
